### PR TITLE
More config options and minor tweaks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.10'
+def runeLiteVersion = '1.8.13.1'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.TickTracker'
-version = '1.0-SNAPSHOT'
+version = '1.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/TickTracker/TickTrackerPlugin.java
+++ b/src/main/java/com/TickTracker/TickTrackerPlugin.java
@@ -2,14 +2,10 @@
 package com.TickTracker;
 
 import com.google.inject.Provides;
-import java.awt.Color;
-import javax.inject.Inject;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
-import static net.runelite.api.GameState.HOPPING;
-import static net.runelite.api.GameState.LOGGING_IN;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.callback.ClientThread;
@@ -23,6 +19,11 @@ import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+
+import static net.runelite.api.GameState.HOPPING;
+import static net.runelite.api.GameState.LOGGING_IN;
 
 
 @PluginDescriptor(
@@ -94,22 +95,6 @@ public class TickTrackerPlugin extends Plugin
 	{
 		overlayManager.add(overlay);
 		overlayManager.add(SmallOverlay);
-	}
-
-	public Color colorSelection()
-	{
-		if (getTickWithinRangePercent() > config.warningColorThreshold())
-		{
-			return Color.GREEN;
-		}
-		else if (getTickWithinRangePercent() > config.warningColorThreshold() - 2)
-		{
-			return Color.YELLOW;
-		}
-		else
-		{
-			return Color.RED;
-		}
 	}
 
 	@Subscribe

--- a/src/main/java/com/TickTracker/TickTrackerPlugin.java
+++ b/src/main/java/com/TickTracker/TickTrackerPlugin.java
@@ -19,6 +19,7 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
@@ -73,7 +74,7 @@ public class TickTrackerPlugin extends Plugin
 	private int allTickCounter = 0;
 	private long runningTickAverageNS = 0;
 	private int disregardCounter = 0;
-	private double tickWithinRangePercent = 0;
+	private double tickWithinRangePercent = 100;
 
 	@Provides
 	TickTrackerPluginConfiguration provideConfig(ConfigManager configManager)
@@ -162,17 +163,36 @@ public class TickTrackerPlugin extends Plugin
 	{
 		if (event.getGameState() == HOPPING || event.getGameState() == LOGGING_IN)
 		{
-			lastTickTimeNS = 0;
-			tickDiffNS = 0;
-			tickTimePassedNS = 0;
-			tickOverThresholdHigh = 0;
-			tickOverThresholdMedium = 0;
-			tickOverThresholdLow = 0;
-			tickWithinRange = 0;
-			allTickCounter = 0;
-			runningTickAverageNS = 0;
-			disregardCounter = 0;
-			tickWithinRangePercent = 0;
+			resetStats(false);
 		}
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event) {
+		if (TickTrackerPluginConfiguration.GROUP.equals(event.getGroup())) {
+			String key = event.getKey();
+			if ("varianceHigh".equals(key) || "varianceMedium".equals(key) || "varianceLow".equals(key)) {
+				resetStats(true);
+			}
+		}
+	}
+
+	private void resetStats(boolean onlyVarianceRelevantStats) {
+		tickOverThresholdHigh = 0;
+		tickOverThresholdMedium = 0;
+		tickOverThresholdLow = 0;
+		tickWithinRange = 0;
+		allTickCounter = 0;
+		tickTimePassedNS = 0;
+		tickWithinRangePercent = 100;
+
+		if (onlyVarianceRelevantStats) {
+			return;
+		}
+
+		lastTickTimeNS = 0;
+		tickDiffNS = 0;
+		runningTickAverageNS = 0;
+		disregardCounter = 0;
 	}
 }

--- a/src/main/java/com/TickTracker/TickTrackerPlugin.java
+++ b/src/main/java/com/TickTracker/TickTrackerPlugin.java
@@ -114,15 +114,15 @@ public class TickTrackerPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick tick)
 	{
+		long tickTimeNS = System.nanoTime();
+		tickDiffNS = tickTimeNS - lastTickTimeNS;
+		lastTickTimeNS = tickTimeNS;
+
 		if (disregardCounter < config.disregardCounter())
 		{
 			disregardCounter += 1; // waiting 10 ticks, because ticks upon login or hopping are funky
 			return;
 		}
-
-		long tickTimeNS = System.nanoTime();
-		tickDiffNS = tickTimeNS - lastTickTimeNS;
-		lastTickTimeNS = tickTimeNS;
 
 		if (tickDiffNS > 2500 * NANOS_PER_MILLIS)
 		{

--- a/src/main/java/com/TickTracker/TickTrackerPluginConfiguration.java
+++ b/src/main/java/com/TickTracker/TickTrackerPluginConfiguration.java
@@ -5,6 +5,7 @@ import com.TickTracker.config.SmallOverlayStyle;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 
 @ConfigGroup(TickTrackerPluginConfiguration.GROUP)
 public interface TickTrackerPluginConfiguration extends Config
@@ -67,21 +68,49 @@ public interface TickTrackerPluginConfiguration extends Config
 	}
 
 	@ConfigItem(
-		keyName = "warningText",
-		name = "Small overlay text color threshold",
-		description = "Above threshold = Green, Above Threshold -2 = Yellow, Below that = Red",
-		position = 6
+			keyName = "colorSmallOverlay",
+			name = "Color Small overlay",
+			description = "Off for yellow, other options use the text color thresholds",
+			position = 6
 	)
-	default int warningColorThreshold()
+	default SmallOverlayStyle smallOverlayColorStyle()
+	{
+		return SmallOverlayStyle.BOTH;
+	}
+
+	@Range(
+			max = 100
+	)
+	@ConfigItem(
+		keyName = "warningText",
+		name = "Color % threshold upper",
+		description = "Above threshold upper = Green, between threshold upper and lower = Yellow, below threshold lower = Red",
+		position = 7
+	)
+	default int warningColorThresholdUpper()
 	{
 		return 90;
+	}
+
+	@Range(
+			max = 100
+	)
+	@ConfigItem(
+		keyName = "warningTextLower",
+		name = "Color % threshold lower",
+		description = "Above threshold upper = Green, between threshold upper and lower = Yellow, below threshold lower = Red",
+		position = 8
+	)
+	default int warningColorThresholdLower()
+	{
+		return 88;
 	}
 
 	@ConfigItem(
 		keyName = "warnLargeTickDiff",
 		name = "Warn in chat about large tick lags",
 		description = "Print notification in chat of ticks over 2500ms",
-		position = 7
+		position = 9
 	)
 	default boolean warnLargeTickDiff()
 	{
@@ -92,7 +121,7 @@ public interface TickTrackerPluginConfiguration extends Config
 		keyName = "disregardCounter",
 		name = "Disregard ticks on login",
 		description = "Ticks on login are very inconsistent. This just disregards x many ticks starting from login to make the plugin more accurate.",
-		position = 8
+		position = 10
 	)
 	default int disregardCounter()
 	{
@@ -103,7 +132,7 @@ public interface TickTrackerPluginConfiguration extends Config
 		keyName = "Y_Offset",
 		name = "Height selector",
 		description = "Modify height of small overlay",
-		position = 9
+		position = 11
 	)
 	default int Y_Offset()
 	{

--- a/src/main/java/com/TickTracker/TickTrackerPluginConfiguration.java
+++ b/src/main/java/com/TickTracker/TickTrackerPluginConfiguration.java
@@ -6,9 +6,11 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("TickTracker")
+@ConfigGroup(TickTrackerPluginConfiguration.GROUP)
 public interface TickTrackerPluginConfiguration extends Config
 {
+	String GROUP = "TickTracker";
+
 	@ConfigItem(
 		keyName = "varianceHigh",
 		name = "Variance High",

--- a/src/main/java/com/TickTracker/TickTrackerSmallOverlay.java
+++ b/src/main/java/com/TickTracker/TickTrackerSmallOverlay.java
@@ -60,17 +60,18 @@ public class TickTrackerSmallOverlay extends OverlayPanel
 		}
 
 		StringBuilder overlayText = new StringBuilder();
-		if (config.drawSmallOverlay() == SmallOverlayStyle.PERCENTAGE || config.drawSmallOverlay() == SmallOverlayStyle.BOTH)
-		{
-			overlayText.append(String.format("%.2f%%", plugin.getTickWithinRangePercent()));
-			if (config.drawSmallOverlay() == SmallOverlayStyle.BOTH)
-			{
-				overlayText.append(" / ");
+		if (plugin.getDisregardCounter() < config.disregardCounter()) {
+			overlayText.append("Waiting...");
+		} else {
+			if (config.drawSmallOverlay() == SmallOverlayStyle.PERCENTAGE || config.drawSmallOverlay() == SmallOverlayStyle.BOTH) {
+				overlayText.append(String.format("%.2f%%", plugin.getTickWithinRangePercent()));
+				if (config.drawSmallOverlay() == SmallOverlayStyle.BOTH) {
+					overlayText.append(" / ");
+				}
 			}
-		}
-		if (config.drawSmallOverlay() == SmallOverlayStyle.LAST_DIFF || config.drawSmallOverlay() == SmallOverlayStyle.BOTH)
-		{
-			overlayText.append(String.format("%dms", plugin.getTickDiffNS() / plugin.getNANOS_PER_MILLIS()));
+			if (config.drawSmallOverlay() == SmallOverlayStyle.LAST_DIFF || config.drawSmallOverlay() == SmallOverlayStyle.BOTH) {
+				overlayText.append(String.format("%dms", plugin.getTickDiffNS() / plugin.getNANOS_PER_MILLIS()));
+			}
 		}
 
 		final int textWidth = graphics.getFontMetrics().stringWidth(overlayText.toString());

--- a/src/main/java/com/TickTracker/config/SmallOverlayStyle.java
+++ b/src/main/java/com/TickTracker/config/SmallOverlayStyle.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SmallOverlayStyle {
     NONE("Off"),
-    PERCENTAGE("Percentage Good"),
+    PERCENTAGE("Percent Good"),
     LAST_DIFF("Last Tick ms"),
     BOTH("Both");
 


### PR DESCRIPTION
+ Small overlay can be fully, partially (either side) coloured, or just always all yellow. Also works when small overlay configured to only show one of the two possible values.
+ Small overlay says "Waiting..." during disregard period instead of 0% etc
+ Stats get reset when a variance boundary config option is changed
+ Tick timing is tracked during disregard period but stats are not updated - this prevents the very large tick length shown for 1 tick at the end of the disregard period (essentially it was showing the value the system returned from nanotime because it didn't have a previous tick to find a difference from)