### PR TITLE
Add 'world' and 'ping' plugin meta tags

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -2,5 +2,5 @@ displayName=Tick Tracker
 author=Tatterss
 support=https://github.com/Tatters654/tick-tracker
 description=A plugin to track server ticks
-tags=tick,timers,skill,pvm,lag
+tags=tick,timers,skill,pvm,lag,world,ping
 plugins=com.TickTracker.TickTrackerPlugin


### PR DESCRIPTION
It would be nice to have these tags too to help find the plugin more easily. Personally, when I was looking to find which plugin had the _world's health_ on my screen, the first thing I searched for was "ping" followed by "world" and "health". I believe these tags accurately fit with the plugin.